### PR TITLE
Fix count query on queries with group by statement.

### DIFF
--- a/src/NetteDatabaseDataSource.php
+++ b/src/NetteDatabaseDataSource.php
@@ -186,9 +186,10 @@ class NetteDatabaseDataSource implements IDataSource
 	{
 		$sql = $this->queryHelper->getCountSelect();
 		$query = $this->query($sql);
-		$rowsCount = $query->getPdoStatement()->rowCount();
+		$rowsCount = $query->getRowCount();
 		switch ($rowsCount){
 			case 0;
+			case null:
 				return 0;
 			case 1:
 				return $query->fetch()->count;

--- a/src/NetteDatabaseDataSource.php
+++ b/src/NetteDatabaseDataSource.php
@@ -185,9 +185,16 @@ class NetteDatabaseDataSource implements IDataSource
 	public function getCount()
 	{
 		$sql = $this->queryHelper->getCountSelect();
-		$query = $this->query($sql)->fetch();
-		
-		return ($query) ? $query->count : 0;
+		$query = $this->query($sql);
+		$rowsCount = $query->getPdoStatement()->rowCount();
+		switch ($rowsCount){
+			case 0;
+				return 0;
+			case 1:
+				return $query->fetch()->count;
+			default:
+				return $rowsCount;
+		}
 	}
 
 


### PR DESCRIPTION
On queries like:
$qry = "
    SELECT
      fb.date
    FROM foo.bar fb
    WHERE fb.date is not null
    GROUP BY date
    ";
$datasource = new NetteDatabaseDataSource($connection, $qry, array());
return $datasource;

getCount not work propertly, because mysql could return more rows "count" as result.