### PR TITLE
Open dev-master 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For details on how to use this package, check out our [documentation](.docs).
 
 | State  | Version  - | Branch | PHP  |
 |--------|------------|--------|------|
-| dev    | dev-master | master | ^7.2 |
+| dev    | ~3.0.0     | master | ^7.2 |
 | stable | ~2.0.0     | master | ^7.2 |
 | stable | ~1.1.0     | master | ^5.6 |
 

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
 		"phpstan": "vendor/phpstan/phpstan/bin/phpstan analyse -c vendor/phpstan/phpstan-strict-rules/rules.neon src --level 7",
 		"phpcs": "vendor/bin/phpcs --standard=vendor/ninjify/coding-standard/ruleset-gamee.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src tests",
 		"phpcsfix": "vendor/bin/phpcbf --standard=vendor/ninjify/coding-standard/ruleset-gamee.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src tests"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "3.0.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
When there is a need for testing new vendor verions and we don't want to use `dev-master`, let's use a branch-alias.