### PR TITLE
Fix default sort

### DIFF
--- a/src/QueryHelper.php
+++ b/src/QueryHelper.php
@@ -106,7 +106,7 @@ class QueryHelper
 
 	public function orderBy(string $column, string $order): string
 	{
-		$this->query['ORDER'] = [[
+		$this->query['ORDER'][] = [
 			'expr_type' => 'colref',
 			'base_expr' => $column,
 			'no_quotes' => [
@@ -115,7 +115,7 @@ class QueryHelper
 			],
 			'subtree'   => false,
 			'direction' => $order,
-		]];
+		];
 
 		return $this->sqlCreator->create($this->query);
 	}


### PR DESCRIPTION
If the array contained more than one column for sorting, only the last one was used.